### PR TITLE
[Fix/#1] waveIndex 0으로 초기화

### DIFF
--- a/src/main/java/com/soohwang/bluebuddy/entity/User.java
+++ b/src/main/java/com/soohwang/bluebuddy/entity/User.java
@@ -30,6 +30,7 @@ public class User implements UserDetails {
     @NotNull
     private String password;
 
+    @NotNull
     private Long waveIndex = 0L;
 
     @Override

--- a/src/main/java/com/soohwang/bluebuddy/service/UserService.java
+++ b/src/main/java/com/soohwang/bluebuddy/service/UserService.java
@@ -29,6 +29,7 @@ public class UserService {
                 .email(signupDto.getEmail())
                 .name(signupDto.getName())
                 .password(passwordEncoder.encode(signupDto.getPassword()))
+                .waveIndex(0L)
                 .build();
 
         userRepository.save(user);


### PR DESCRIPTION
## 📌 관련 이슈
#1 #2

## ✨ 작업 내용
회원가입 시 waveIndex가 null로 초기화 되어 출석체크 할 때 연산이 안 되는 문제 발생
builder에서 명시적으로 0으로 초기화하도록 수정

## 📸 스크린샷(선택)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
